### PR TITLE
Bump Litho version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Litho Lint rules is a project that contains Lint rules generated according to [L
 ## Usage
 
 ```groovy
-compile 'com.github.pavlospt:litho-lint:1.4'
+compile 'com.github.pavlospt:litho-lint:1.5'
 ```
 
 Run `Code Inspection` through Android Studio or just run `./gradlew clean :app:lint`

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion versions.compileSdk
-  buildToolsVersion versions.buildTools
 
   defaultConfig {
     applicationId "com.github.pavlospt.litholintrulessample"

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,15 @@
 buildscript {
   ext.versions = [
           'minSdk'          : 15,
-          'compileSdk'      : 27,
-          'targetSdk'       : 27,
-          'buildTools'      : '27.0.3',
-          'supportLibrary'  : '27.1.0',
+          'compileSdk'      : 28,
+          'targetSdk'       : 28,
+          'supportLibrary'  : '28.0.0',
           'constraintLayout': '1.0.2',
-          'soLoader'        : '0.2.0',
-          'litho'           : '0.13.1',
-          'androidPlugin'   : '3.1.0',
-          'androidTools'    : '26.1.0-rc03',
-          'kotlin'          : '1.2.21'
+          'soLoader'        : '0.5.1',
+          'litho'           : '0.20.0',
+          'androidPlugin'   : '3.2.0',
+          'androidTools'    : '26.2.1',
+          'kotlin'          : '1.2.71'
   ]
 
   ext.deps = [
@@ -34,8 +33,8 @@ buildscript {
   ]
 
   repositories {
-    jcenter()
     google()
+    jcenter()
   }
   dependencies {
     classpath deps.android.gradlePlugin
@@ -44,9 +43,9 @@ buildscript {
 
 allprojects {
   repositories {
-    jcenter()
-    mavenCentral()
     google()
+    mavenCentral()
+    jcenter()
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx1536m
 
-VERSION_NAME=1.4
-VERSION_CODE=5
+VERSION_NAME=1.5
+VERSION_CODE=6
 GROUP=com.github.pavlospt
 
 POM_DESCRIPTION=Lint rules for Litho

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/litho-lint-detector/src/main/java/com/github/pavlospt/LithoLintIssuesDetector.kt
+++ b/litho-lint-detector/src/main/java/com/github/pavlospt/LithoLintIssuesDetector.kt
@@ -56,23 +56,21 @@ class LithoLintIssuesDetector : Detector(), Detector.UastScanner {
     private fun detectAnnotatedClassNameIssue(context: JavaContext?, uClass: UClass) {
       if (!PsiUtils.hasAnnotations(uClass.modifierList)) return
 
-      val annotations = uClass.modifierList?.annotations
+      val annotations = uClass.modifierList?.annotations ?: return
 
-      annotations?.let {
-        it.forEach annotationsLoop@{
-          val worthCheckingClass = LithoLintConstants.LAYOUT_SPEC_ANNOTATION == it.qualifiedName
+      annotations.forEach {
+        val worthCheckingClass = LithoLintConstants.LAYOUT_SPEC_ANNOTATION == it.qualifiedName
 
-          val psiClassName = uClass.name ?: return@annotationsLoop
+        val psiClassName = uClass.name ?: return@forEach
 
-          val notSuggestedName = LithoLintConstants.SUGGESTED_LAYOUT_COMPONENT_SPEC_NAME_FORMAT !in psiClassName
+        val notSuggestedName = LithoLintConstants.SUGGESTED_LAYOUT_COMPONENT_SPEC_NAME_FORMAT !in psiClassName
 
-          val shouldReportClass = worthCheckingClass && notSuggestedName
+        val shouldReportClass = worthCheckingClass && notSuggestedName
 
-          if (shouldReportClass) {
-            context?.report(IssuesInfo.LAYOUT_SPEC_NAME_ISSUE, it,
-                context.getLocation(uClass.psi.nameIdentifier as PsiElement),
-                IssuesInfo.LAYOUT_SPEC_CLASS_NAME_ISSUE_DESC)
-          }
+        if (shouldReportClass) {
+          context?.report(IssuesInfo.LAYOUT_SPEC_NAME_ISSUE, it,
+              context.getLocation(uClass.psi.nameIdentifier as PsiElement),
+              IssuesInfo.LAYOUT_SPEC_CLASS_NAME_ISSUE_DESC)
         }
       }
     }

--- a/litho-lint/build.gradle
+++ b/litho-lint/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion versions.compileSdk
-  buildToolsVersion versions.buildTools
 
   defaultConfig {
     minSdkVersion versions.minSdk

--- a/litho-lint/build.gradle
+++ b/litho-lint/build.gradle
@@ -6,8 +6,8 @@ android {
   defaultConfig {
     minSdkVersion versions.minSdk
     targetSdkVersion versions.targetSdk
-    versionCode 5
-    versionName "1.4"
+    versionCode 6
+    versionName "1.5"
   }
 
   lintOptions {
@@ -41,7 +41,7 @@ project.afterEvaluate {
 ext {
   PUBLISH_GROUP_ID = 'com.github.pavlospt'
   PUBLISH_ARTIFACT_ID = 'litho-lint'
-  PUBLISH_VERSION = '1.4'
+  PUBLISH_VERSION = '1.5'
 }
 
 //apply from: 'https://raw.githubusercontent.com/ArthurHub/release-android-library/master/android-release-aar.gradle'


### PR DESCRIPTION
This PR includes:

* Litho version bump to 0.20.0
* SoLoader version bump to 0.5.1
* Compile SDK version bump to 28
* Target SDK version bump to 28
* AGP version bump to 3.2.0
* New version of library 1.5
